### PR TITLE
Update Huey License and README for clarity and acknowledgment requirements

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Follow the licensing requirements under all situations, thank you.

--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,16 @@
-# Huey License (Based on AGPL-3.0)
+Huey License (Based on AGPL-3.0)
 
-**Preamble**
+Preamble
 
 This license is based on the GNU Affero General Public License, version 3 (AGPL-3.0). It grants users the freedom to use, modify, and distribute the software, provided that modifications and improvements are shared with the community under the same terms. Additionally, any derivative work, service, or software that incorporates this project, *Huey*, must acknowledge its use of the project.
 
----
+Terms and Conditions for Copying, Distribution, and Modification
 
-## Terms and Conditions for Copying, Distribution, and Modification
-
-**0. Definitions**
+1. Definitions
 
 This License applies to any program or other work that contains a notice placed by the copyright holder stating it is licensed under the terms of this *Huey License*.
 
-**1. Additional Requirement: Acknowledgment of Use**
+2. Additional Requirement: Acknowledgment of Use
 
 In addition to the conditions set forth in AGPL-3.0, the following terms apply:
 
@@ -20,13 +18,10 @@ In addition to the conditions set forth in AGPL-3.0, the following terms apply:
   
 - The acknowledgment must be retained in any modified versions and be accessible to users or viewers of the derived work in a prominent place.
 
-**2. Remaining License Terms**
+3. Remaining License Terms
 
 All other terms of the AGPL-3.0 apply to this software. You must comply with the AGPL-3.0 in all respects, with the additional acknowledgment requirement listed above.
 
----
-
-**END OF TERMS AND CONDITIONS**
 
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
@@ -89,7 +84,7 @@ modification follow.
 
                        TERMS AND CONDITIONS
 
-  0. Definitions.
+  1. Definitions.
 
   "This License" refers to version 3 of the GNU Affero General Public License.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,34 @@
+# Huey License (Based on AGPL-3.0)
+
+**Preamble**
+
+This license is based on the GNU Affero General Public License, version 3 (AGPL-3.0). It grants users the freedom to use, modify, and distribute the software, provided that modifications and improvements are shared with the community under the same terms. Additionally, any derivative work, service, or software that incorporates this project, *Huey*, must acknowledge its use of the project.
+
+---
+
+## Terms and Conditions for Copying, Distribution, and Modification
+
+**0. Definitions**
+
+This License applies to any program or other work that contains a notice placed by the copyright holder stating it is licensed under the terms of this *Huey License*.
+
+**1. Additional Requirement: Acknowledgment of Use**
+
+In addition to the conditions set forth in AGPL-3.0, the following terms apply:
+
+- Any work, product, or service that includes or is derived from the Huey project, or any modified version of it, must include a clear and visible acknowledgment in the documentation, source code, or user interface stating: “This project uses Huey, originally developed by Jasper Visser.”
+  
+- The acknowledgment must be retained in any modified versions and be accessible to users or viewers of the derived work in a prominent place.
+
+**2. Remaining License Terms**
+
+All other terms of the AGPL-3.0 apply to this software. You must comply with the AGPL-3.0 in all respects, with the additional acknowledgment requirement listed above.
+
+---
+
+**END OF TERMS AND CONDITIONS**
+
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,37 @@
 
 A utility script to produce color variations of clothing within Unity for Unturned.
 
+# Huey License (Based on AGPL-3.0)
+
+**Preamble**
+
+This license is based on the GNU Affero General Public License, version 3 (AGPL-3.0). It grants users the freedom to use, modify, and distribute the software, provided that modifications and improvements are shared with the community under the same terms. Additionally, any derivative work, service, or software that incorporates this project, *Huey*, must acknowledge its use of the project.
+
+## Terms and Conditions for Copying, Distribution, and Modification
+
+**0. Definitions**
+
+This License applies to any program or other work that contains a notice placed by the copyright holder stating it is licensed under the terms of this *Huey License*.
+
+**1. Additional Requirement: Acknowledgment of Use**
+
+In addition to the conditions set forth in AGPL-3.0, the following terms apply:
+
+- Any work, product, or service that includes or is derived from the Huey project, or any modified version of it, must include a clear and visible acknowledgment in the documentation, source code, or user interface stating: “This project uses Huey, originally developed by Jasper Visser.”
+  
+- The acknowledgment must be retained in any modified versions and be accessible to users or viewers of the derived work in a prominent place.
+
+**2. Remaining License Terms**
+
+All other terms of the AGPL-3.0 apply to this software. You must comply with the AGPL-3.0 in all respects, with the additional acknowledgment requirement listed above.
+
+---
+
 ## 1. Table of Contents
 
 - [Huey (v2)](#huey-v2)
+- [Huey License (Based on AGPL-3.0)](#huey-license-based-on-agpl-30)
+  - [Terms and Conditions for Copying, Distribution, and Modification](#terms-and-conditions-for-copying-distribution-and-modification)
   - [1. Table of Contents](#1-table-of-contents)
   - [2. How to install](#2-how-to-install)
     - [2.1. Unity Package File](#21-unity-package-file)

--- a/README.md
+++ b/README.md
@@ -2,37 +2,11 @@
 
 A utility script to produce color variations of clothing within Unity for Unturned.
 
-# Huey License (Based on AGPL-3.0)
-
-**Preamble**
-
-This license is based on the GNU Affero General Public License, version 3 (AGPL-3.0). It grants users the freedom to use, modify, and distribute the software, provided that modifications and improvements are shared with the community under the same terms. Additionally, any derivative work, service, or software that incorporates this project, *Huey*, must acknowledge its use of the project.
-
-## Terms and Conditions for Copying, Distribution, and Modification
-
-**0. Definitions**
-
-This License applies to any program or other work that contains a notice placed by the copyright holder stating it is licensed under the terms of this *Huey License*.
-
-**1. Additional Requirement: Acknowledgment of Use**
-
-In addition to the conditions set forth in AGPL-3.0, the following terms apply:
-
-- Any work, product, or service that includes or is derived from the Huey project, or any modified version of it, must include a clear and visible acknowledgment in the documentation, source code, or user interface stating: “This project uses Huey, originally developed by Jasper Visser.”
-  
-- The acknowledgment must be retained in any modified versions and be accessible to users or viewers of the derived work in a prominent place.
-
-**2. Remaining License Terms**
-
-All other terms of the AGPL-3.0 apply to this software. You must comply with the AGPL-3.0 in all respects, with the additional acknowledgment requirement listed above.
-
 ---
 
 ## 1. Table of Contents
 
 - [Huey (v2)](#huey-v2)
-- [Huey License (Based on AGPL-3.0)](#huey-license-based-on-agpl-30)
-  - [Terms and Conditions for Copying, Distribution, and Modification](#terms-and-conditions-for-copying-distribution-and-modification)
   - [1. Table of Contents](#1-table-of-contents)
   - [2. How to install](#2-how-to-install)
     - [2.1. Unity Package File](#21-unity-package-file)
@@ -41,6 +15,8 @@ All other terms of the AGPL-3.0 apply to this software. You must comply with the
     - [3.1. Using textures](#31-using-textures)
     - [3.2. Different colors](#32-different-colors)
     - [3.3. Overlay](#33-overlay)
+- [License](#license)
+  - [Terms and Conditions for Copying, Distribution, and Modification](#terms-and-conditions-for-copying-distribution-and-modification)
 
 ## 2. How to install
 
@@ -71,3 +47,29 @@ You can always add or remove colors, the colors are modified using the Hue, Satu
 ### 3.3. Overlay
 
 If you want a part of an image not to be changed from color you can make an Overlay.png, an Overlay.png will be overlayed on any PNG file within the directory. This will allow you to easily add shoes, such as the example for the shorts.
+
+---
+
+# License
+
+**Preamble**
+
+This license is based on the GNU Affero General Public License, version 3 (AGPL-3.0). It grants users the freedom to use, modify, and distribute the software, provided that modifications and improvements are shared with the community under the same terms. Additionally, any derivative work, service, or software that incorporates this project, *Huey*, must acknowledge its use of the project.
+
+## Terms and Conditions for Copying, Distribution, and Modification
+
+**0. Definitions**
+
+This License applies to any program or other work that contains a notice placed by the copyright holder stating it is licensed under the terms of this *Huey License*.
+
+**1. Additional Requirement: Acknowledgment of Use**
+
+In addition to the conditions set forth in AGPL-3.0, the following terms apply:
+
+- Any work, product, or service that includes or is derived from the Huey project, or any modified version of it, must include a clear and visible acknowledgment in the documentation, source code, or user interface stating: “This project uses Huey, originally developed by Jasper Visser.”
+  
+- The acknowledgment must be retained in any modified versions and be accessible to users or viewers of the derived work in a prominent place.
+
+**2. Remaining License Terms**
+
+All other terms of the AGPL-3.0 apply to this software. You must comply with the AGPL-3.0 in all respects, with the additional acknowledgment requirement listed above.


### PR DESCRIPTION
Introduce a revised Huey License based on AGPL-3.0, emphasizing the acknowledgment requirement for derivative works. Restructure the README to clarify licensing terms and include a CODE_OF_CONDUCT file outlining these requirements.